### PR TITLE
set proper dependency link

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "css"
   ],
   "dependencies": {
-    "fontfacegen": "https://github.com/original001/fontfacegen.git"
+    "fontfacegen": "original001/fontfacegen"
   }
 }


### PR DESCRIPTION
```
─$ npm install original001/grunt-fontgen --save-dev
npm WARN package.json new_main@0.0.1 No repository field.
npm ERR! fetch failed https://github.com/original001/fontfacegen.git
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 406
```
